### PR TITLE
Added support for from_email field to send method

### DIFF
--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -71,7 +71,7 @@ class BaseEmailMessage(mail.EmailMultiAlternatives):
         self.cc = kwargs.pop('cc', [])
         self.bcc = kwargs.pop('bcc', [])
         self.reply_to = kwargs.pop('reply_to', [])
-        self.from_email = kwargs.pop('from_email', [])
+        self.from_email = kwargs.pop('from_email', '')
 
         super(BaseEmailMessage, self).send(*args, **kwargs)
 

--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -1,11 +1,10 @@
 from copy import deepcopy
 
+from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
 from django.template.context import make_context
 from django.template.loader import get_template
-
-from django.conf import settings
 
 
 class BaseEmailMessage(mail.EmailMultiAlternatives):
@@ -72,6 +71,7 @@ class BaseEmailMessage(mail.EmailMultiAlternatives):
         self.cc = kwargs.pop('cc', [])
         self.bcc = kwargs.pop('bcc', [])
         self.reply_to = kwargs.pop('reply_to', [])
+        self.from_email = kwargs.pop('from_email', [])
 
         super(BaseEmailMessage, self).send(*args, **kwargs)
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
 from django.test import RequestFactory, TestCase
-
 from templated_mail.mail import BaseEmailMessage
 
 
@@ -182,6 +181,24 @@ class TestBaseEmailMessage(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, self.recipients)
         self.assertEqual(mail.outbox[0].reply_to, reply_to)
+        self.assertEqual(mail.outbox[0].subject, 'Text mail subject')
+        self.assertEqual(mail.outbox[0].body, 'Foobar email content')
+        self.assertEqual(mail.outbox[0].alternatives, [])
+        self.assertEqual(mail.outbox[0].content_subtype, 'plain')
+
+    def test_mail_from_email_is_sent_with_valid_from_email(self):
+        request = self.factory.get('/')
+        request.user = AnonymousUser()
+
+        from_email = ['email@example.tld']
+
+        BaseEmailMessage(
+            request=request, template_name='text_mail.html'
+        ).send(to=self.recipients, from_email=from_email)
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, self.recipients)
+        self.assertEqual(mail.outbox[0].from_email, from_email)
         self.assertEqual(mail.outbox[0].subject, 'Text mail subject')
         self.assertEqual(mail.outbox[0].body, 'Foobar email content')
         self.assertEqual(mail.outbox[0].alternatives, [])

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -190,7 +190,7 @@ class TestBaseEmailMessage(TestCase):
         request = self.factory.get('/')
         request.user = AnonymousUser()
 
-        from_email = ['email@example.tld']
+        from_email = '<Example - email@example.tld>'
 
         BaseEmailMessage(
             request=request, template_name='text_mail.html'


### PR DESCRIPTION
EmailMultiAlternatives supports `from_email`, added support for this field and written a test

https://docs.djangoproject.com/en/2.0/topics/email/