### PR TITLE
Feature: pass context to mixins on BaseEmailMessage

### DIFF
--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -27,7 +27,7 @@ class BaseEmailMessage(mail.EmailMultiAlternatives, ContextMixin):
 
     def get_context_data(self, **kwargs):
         ctx = super(BaseEmailMessage, self).get_context_data(**kwargs)
-        context = dict(ctx.items() | self.context.items())
+        context = dict(ctx, **self.context)
         if self.request:
             site = get_current_site(self.request)
             domain = context.get('domain') or (

--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
@@ -27,7 +25,8 @@ class BaseEmailMessage(mail.EmailMultiAlternatives):
             self.template_name = template_name
 
     def get_context_data(self):
-        context = deepcopy(self.context)
+        _context = super(BaseEmailMessage, self).get_context_data(**kwargs)
+        context = dict(_context.items() + self.context.items())
         if self.request:
             site = get_current_site(self.request)
             domain = context.get('domain') or (

--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -3,9 +3,10 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core import mail
 from django.template.context import make_context
 from django.template.loader import get_template
+from django.views.generic.base import ContextMixin
 
 
-class BaseEmailMessage(mail.EmailMultiAlternatives):
+class BaseEmailMessage(mail.EmailMultiAlternatives, ContextMixin):
     _node_map = {
         'subject': 'subject',
         'text_body': 'body',
@@ -24,9 +25,9 @@ class BaseEmailMessage(mail.EmailMultiAlternatives):
         if template_name is not None:
             self.template_name = template_name
 
-    def get_context_data(self):
-        _context = super(BaseEmailMessage, self).get_context_data(**kwargs)
-        context = dict(_context.items() + self.context.items())
+    def get_context_data(self, **kwargs):
+        ctx = super(BaseEmailMessage, self).get_context_data(**kwargs)
+        context = dict(ctx.items() | self.context.items())
         if self.request:
             site = get_current_site(self.request)
             domain = context.get('domain') or (

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,13 @@
+from django.views.generic.base import ContextMixin
+from templated_mail.mail import BaseEmailMessage
+
+
+class MockMailContext(ContextMixin):
+    def get_context_data(self, **kwargs):
+        context = super(MockMailContext, self).get_context_data(**kwargs)
+        context['thing'] = 42
+        return context
+
+
+class MockMail(BaseEmailMessage, MockMailContext):
+    pass

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -9,6 +9,8 @@ from django.core import mail
 from django.test import RequestFactory, TestCase
 from templated_mail.mail import BaseEmailMessage
 
+from .helpers import MockMail
+
 
 class TestBaseEmailMessage(TestCase):
     def setUp(self):
@@ -203,3 +205,13 @@ class TestBaseEmailMessage(TestCase):
         self.assertEqual(mail.outbox[0].body, 'Foobar email content')
         self.assertEqual(mail.outbox[0].alternatives, [])
         self.assertEqual(mail.outbox[0].content_subtype, 'plain')
+
+    def test_extending_mail_with_context_mixin(self):
+        email_message = MockMail(
+            template_name='text_mail.html', context={'foo': 'bar'}
+        )
+
+        context = email_message.get_context_data()
+
+        self.assertEquals(context['foo'], 'bar')
+        self.assertEquals(context['thing'], 42)


### PR DESCRIPTION
I had a problem with extending `BaseEmailMessage`, it would lose context passed from the instance due to `get_context_data` method missing a super call.

For example:
```python
class MailContextMixin(ContextMixin):
    get_context_data(self, **kwargs):
        context = super(MailContextMixin, self).get_context_data(**kwargs)
        context['thing'] = SomeRandomThing() # need this on every mail message

class NotifyMail(BaseEmailMessage, MailContextMixin):
   pass

class PasswordResetMail(BaseEmailMessage, MailContextMixin):
   pass

mail = NotifyMail(context={'more': 'never to be seen again'}) 
# this context gets lost due to BaseEmailMessage not applying super to get_context_data.
```