### PR TITLE
Fix: from_email should return None by default

### DIFF
--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -71,7 +71,7 @@ class BaseEmailMessage(mail.EmailMultiAlternatives, ContextMixin):
         self.cc = kwargs.pop('cc', [])
         self.bcc = kwargs.pop('bcc', [])
         self.reply_to = kwargs.pop('reply_to', [])
-        self.from_email = kwargs.pop('from_email', '')
+        self.from_email = kwargs.pop('from_email', None)
 
         super(BaseEmailMessage, self).send(*args, **kwargs)
 


### PR DESCRIPTION
>  If from_email is None, use the DEFAULT_FROM_EMAIL setting.
https://docs.djangoproject.com/en/2.0/_modules/django/core/mail/#send_mail

@piotr-szpetkowski didn't see this problem. Tested against a SMTP server with from_email address set to None, this works. A string is indeed not valid.

This PR will fixes #4

