### PR TITLE
Update settings from dict format to variable format

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -5,8 +5,8 @@ You may optionally provide following settings:
 
 .. code-block:: python
 
-    'DOMAIN': 'example.com'
-    'SITE_NAME': 'Foo Website'
+    DOMAIN = 'example.com'
+    SITE_NAME = 'Foo Website'
 
 DOMAIN
 ------


### PR DESCRIPTION
It seems that in django-templated-email, you're using straight variables inside the settings file, instead of a nested dictionary like in djoser, and the variable names should reflect that in the documentation for that