### PR TITLE
Allow a change the name of template_name attribute

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -7,6 +7,7 @@ You may optionally provide following settings:
 
     'DOMAIN': 'example.com'
     'SITE_NAME': 'Foo Website'
+    'TEMPLATE_ATTRIBUTE': 'django_template_name'
 
 DOMAIN
 ------
@@ -26,3 +27,15 @@ app. If not provided the current site's name will be used.
 
 
 **Default**: ``False``
+
+TEMPLATE_ATTRIBUTE
+---------
+
+It can happen that the attribute ``template_name`` causes problems when sending
+e-mail. This will happen e.g. when you send your e-mail by ``django-anymail``
+with Mandrill backend. In this case this attribute would be interpreted as
+Mandrill's template. In cases like this you can change change the name of the
+attribute to something that doesn't cause conflict.
+
+
+**Default**: ``template_name``

--- a/templated_mail/mail.py
+++ b/templated_mail/mail.py
@@ -6,13 +6,14 @@ from django.template.loader import get_template
 from django.views.generic.base import ContextMixin
 
 
+
+
 class BaseEmailMessage(mail.EmailMultiAlternatives, ContextMixin):
     _node_map = {
         'subject': 'subject',
         'text_body': 'body',
         'html_body': 'html',
     }
-    template_name = None
 
     def __init__(self, request=None, context=None, template_name=None,
                  *args, **kwargs):
@@ -21,9 +22,13 @@ class BaseEmailMessage(mail.EmailMultiAlternatives, ContextMixin):
         self.request = request
         self.context = {} if context is None else context
         self.html = None
+        self.template_name_attribute = getattr(
+            settings, 'TEMPLATE_ATTRIBUTE', 'template_name',
+        )
+
 
         if template_name is not None:
-            self.template_name = template_name
+            setattr(self, self.template_name_attribute, template_name)
 
     def get_context_data(self, **kwargs):
         ctx = super(BaseEmailMessage, self).get_context_data(**kwargs)
@@ -58,7 +63,8 @@ class BaseEmailMessage(mail.EmailMultiAlternatives, ContextMixin):
 
     def render(self):
         context = make_context(self.get_context_data(), request=self.request)
-        template = get_template(self.template_name)
+        template_name = getattr(self, self.template_name_attribute)
+        template = get_template(template_name)
         with context.bind_template(template.template):
             for node in template.template.nodelist:
                 self._process_node(node, context)

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -104,6 +104,18 @@ class TestBaseEmailMessage(TestCase):
         self.assertEqual(mail.outbox[0].alternatives, [])
         self.assertEqual(mail.outbox[0].content_subtype, 'html')
 
+    @override_settings(TEMPLATE_ATTRIBUTE='django_template_name')
+    def test_alternative_attribute(self):
+        request = self.factory.get('/')
+        request.user = AnonymousUser()
+        message = BaseEmailMessage(
+            request=request, template_name='html_mail.html'
+        )
+        self.assertIsNone(getattr(message, 'template_name', None))
+        self.assertEqual(message.django_template_name, 'html_mail.html')
+        message.send(to=self.recipients)
+        self.assertEqual(mail.outbox[0].body, '<p>Foobar email content</p>')
+
     def test_text_and_html_mail_contains_valid_data(self):
         request = self.factory.get('/')
         request.user = AnonymousUser()


### PR DESCRIPTION
A name conflict was reported when using Mandrill. Ability
to change the attribute name can be useful.
The problem is reported here: https://github.com/sunscrapers/djoser/issues/331